### PR TITLE
px4_dev base: add python-numpy

### DIFF
--- a/docker/px4-dev/Dockerfile_base
+++ b/docker/px4-dev/Dockerfile_base
@@ -26,6 +26,7 @@ RUN apt-get update \
 		patch \
 		python-argparse \
 		python-empy \
+		python-numpy \
 		python-pip \
 		python-serial \
 		python-software-properties \


### PR DESCRIPTION
Needed by https://github.com/PX4/Firmware/pull/8063